### PR TITLE
[SRM-526] Added new ci config to update reference branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,18 @@
 version: 2
 aliases:
+  - &ssh_key_fingerprint "36:03:e3:ca:b3:0b:82:18:e2:e9:ae:5d:81:17:86:b1"
+  # Fingerprint of the SSH deploy key of the project used to pull code.
+  # The value can be found in CircleCI UI -> SSH Permissions.
+
+  - &step_configure_git
+    run:
+      name: Configure git
+      command: |
+        git config --global user.email "$DEPLOY_USER_EMAIL" && git config --global user.name "$DEPLOY_USER_NAME"
+        
   # Re-usable job to run different types of builds.
   - &job-build
-    working_directory: /app
+    working_directory: &working-directory /app
     docker:
       - image: &builder-image singledigital/bay-ci-builder:4.x
         environment:
@@ -25,6 +35,35 @@ aliases:
       - store_artifacts:
           path: /tmp/artifacts
 
+  # Job to perform merge to reference branch after a merge to develop.
+  - &merge-to-reference
+    working_directory: *working-directory
+    docker:
+      - image: *builder-image
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
+        environment:
+          LAGOON_ENVIRONMENT_TYPE: ci
+          SSH_KEY_FINGERPRINT: *ssh_key_fingerprint
+          DEPLOY_USER_EMAIL: sdp.devs@dpc.vic.gov.au
+          DEPLOY_USER_NAME: sdpdeploy
+    steps:
+      - attach_workspace:
+          at: /workspace
+      - checkout
+      - *step_configure_git
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - add_ssh_keys:
+          fingerprints:
+            - *ssh_key_fingerprint
+      - run:
+          name: Merge to reference branch
+          command: .circleci/merge-to-reference.sh
+          no_output_timeout: 30m
+
+
 jobs:
   build:
     <<: *job-build
@@ -38,10 +77,22 @@ jobs:
           LAGOON_ENVIRONMENT_TYPE: ci
           INSTALL_SUGGEST: 1
           BEHAT_PROFILE: "--profile=suggest"
+  
+  merge_to_reference:
+    <<: *merge-to-reference
 
+        
 workflows:
   version: 2
   main:
     jobs:
       - build
       - build_suggest
+
+  mergetoreference:
+    jobs:
+      - merge_to_reference:
+          filters:
+            branches:
+              only:
+                - develop

--- a/.circleci/merge-to-reference.sh
+++ b/.circleci/merge-to-reference.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+##
+# Merge develop to reference branch in CI.
+#
+
+echo "==> Checking out reference branch"
+git checkout reference
+echo "==> Merging develop to reference branch"
+git merge develop
+git checkout --theirs composer.json
+git add .
+echo "==> Replacing composer require entries starting with dpc-sdp with value dev-reference"
+cat composer.json | gojq '.require |= with_entries(
+  if (.key | test("dpc-sdp/tide_event"))
+  then .value = "dev-reference" else . end)' > composer.json.backup && mv -f composer.json.backup composer.json
+echo "==> Add all changes"
+git add .
+git commit -m "Merge changes from develop."
+echo "==> Push the changes to remote reference branch"
+git push origin --force reference

--- a/.circleci/merge-to-reference.sh
+++ b/.circleci/merge-to-reference.sh
@@ -7,12 +7,13 @@ echo "==> Checking out reference branch"
 git checkout reference
 echo "==> Merging develop to reference branch"
 git merge develop
-git checkout --theirs composer.json
+git checkout develop -- composer.json
 git add .
 echo "==> Replacing composer require entries starting with dpc-sdp with value dev-reference"
 cat composer.json | gojq '.require |= with_entries(
-  if (.key | test("dpc-sdp/tide_event"))
-  then .value = "dev-reference" else . end)' > composer.json.backup && mv -f composer.json.backup composer.json
+  if (.key | test("dpc-sdp/tide"))
+  then .value = "dev-reference" end)' > composer.json.backup
+mv -f composer.json.backup composer.json
 echo "==> Add all changes"
 git add .
 git commit -m "Merge changes from develop."


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SRM-526

### Motivation
Reference site composer needs to keep itself updated to with the latest develop of tide modules. But pointing to develop and creating aliases in the root composer of content-reference will create conflict issue after every release with difference version. So creating a reference branch on tide profile and tide_* modules and updating this reference branch with develop branch changes every time there is a merge in develop, will solve the conflicting issue. So in the content reference root composer, just use this tide profile branch named reference.

### Changes
Added a CI job, which will get triggered only for develop branch on every build and it will merge the changes from develop branch to the reference branch. This way we do not have to maintain this branch manually and it will be always up to date with develop and content-reference will be using this to get all the latest changes from develop.