### PR TITLE
Ensure we check presence of variable before using it

### DIFF
--- a/tide_event.module
+++ b/tide_event.module
@@ -79,7 +79,7 @@ function tide_event_search_api_index_items_alter(IndexInterface $index, array &$
       $path = Url::fromUri($uri)->toString();
     }
 
-    if ($path) {
+    if (isset($path)) {
       $field_link->setValues([$path]);
       $item->setField('field_paragraph_link', $field_link);
     }


### PR DESCRIPTION
It's producing warnings on latest develop on content-reference, under PHP 8.1

![image](https://user-images.githubusercontent.com/496095/217730373-f93a4f50-9961-471c-a584-c27a4b8eabeb.png)
