### PR TITLE
Fix errors with doing search api indexing

### DIFF
--- a/tide_event.module
+++ b/tide_event.module
@@ -72,7 +72,10 @@ function tide_event_search_api_index_items_alter(IndexInterface $index, array &$
     $field_link = $item->getField('field_paragraph_link');
 
     if (isset($field_link)) {
-      $uri = $field_link->getValues()[0];
+      $values = $field_link->getValues();
+      if (is_array($values) && isset($values[0])) {
+        $uri = $values[0];
+      }
     }
 
     if (isset($uri)) {


### PR DESCRIPTION
This commit fixes problems coming up in content-vic search indexing on build

```
>  [warning] Undefined array key 0 tide_event.module:75
>  [warning] Undefined variable $path tide_event.module:82
```

@MdNadimHossain please review